### PR TITLE
v0.6.0: canvas polish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kemopin"
-version = "0.5.0"
+version = "0.6.0"
 description = "Self-hosted freeform moodboard"
 requires-python = ">=3.12"
 dependencies = [

--- a/static/js/canvas.js
+++ b/static/js/canvas.js
@@ -1,5 +1,5 @@
 import { state } from "./state.js";
-import { TEXT_COLORS } from "./constants.js";
+import { TEXT_COLORS, snapToGrid } from "./constants.js";
 import { serializeElement } from "./serialize.js";
 import { pushHistory, undo, redo } from "./history.js";
 import { createTextNode, duplicateFrom, fitToView, bringForward, sendBackward } from "./elements.js";
@@ -67,7 +67,7 @@ export function setupCanvas() {
     state.stage.on("dblclick dbltap", function (e) {
         if (e.target !== state.stage) return;
         var p = state.stage.getRelativePointerPosition();
-        createTextNode(p.x, p.y, "", 16);
+        createTextNode(snapToGrid(p.x), snapToGrid(p.y), "", 16);
     });
 
     window.addEventListener("resize", function () {
@@ -177,8 +177,8 @@ function setupPaste() {
                     var el = data.element;
                     var viewW = state.stage.width()  / state.stage.scaleX();
                     var viewH = state.stage.height() / state.stage.scaleY();
-                    var cx = -state.stage.x() / state.stage.scaleX() + viewW / 2;
-                    var cy = -state.stage.y() / state.stage.scaleY() + viewH / 2;
+                    var cx = snapToGrid(-state.stage.x() / state.stage.scaleX() + viewW / 2);
+                    var cy = snapToGrid(-state.stage.y() / state.stage.scaleY() + viewH / 2);
                     var elH = el.height || 50;
                     state.pasteCount++;
                     var offset = state.pasteCount * 20;

--- a/static/js/canvas.js
+++ b/static/js/canvas.js
@@ -2,7 +2,7 @@ import { state } from "./state.js";
 import { TEXT_COLORS } from "./constants.js";
 import { serializeElement } from "./serialize.js";
 import { pushHistory, undo, redo } from "./history.js";
-import { createTextNode, duplicateFrom, fitToView } from "./elements.js";
+import { createTextNode, duplicateFrom, fitToView, bringForward, sendBackward } from "./elements.js";
 import { openFilePicker, uploadAndAddImage, fetchAndUploadFromUrl } from "./upload.js";
 import { performSave } from "./save.js";
 import { toast } from "./utils.js";
@@ -235,6 +235,8 @@ function setupKeyboard() {
         if (e.key === "h") { overlay.classList.toggle("visible"); return; }
         if (e.key === "Escape") { overlay.classList.remove("visible"); return; }
         if (e.key === "o") { openFilePicker(); return; }
+        if (ctrl && e.key === "ArrowUp")   { e.preventDefault(); if (selected) bringForward(selected); return; }
+        if (ctrl && e.key === "ArrowDown") { e.preventDefault(); if (selected) sendBackward(selected); return; }
 
         if (e.key === "c" && !ctrl && selected instanceof Konva.Text) {
             var ci = TEXT_COLORS.indexOf(selected.fill());

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -1,4 +1,5 @@
 export const GRID_SIZE      = 20;
+export function snapToGrid(val) { return Math.round(val / GRID_SIZE) * GRID_SIZE; }
 export const AUTOSAVE_DELAY = 30000;
 
 export const TEXT_COLORS = [
@@ -18,16 +19,18 @@ export const SHORTCUTS = [
         { key: "Alt + drag",    desc: "free placement" },
         { key: "Alt + rotate",  desc: "free rotation" },
         { key: "Del",           desc: "delete selected" },
+        { key: "C",             desc: "cycle text color" },
+        { key: "A",             desc: "cycle text align" },
     ],
     [
-        { key: "C",      desc: "cycle text color" },
-        { key: "A",      desc: "cycle text align" },
         { key: "Ctrl C", desc: "copy selected" },
         { key: "Ctrl V", desc: "paste" },
         { key: "Ctrl D", desc: "duplicate" },
         { key: "Ctrl S", desc: "save" },
         { key: "Ctrl Z", desc: "undo" },
         { key: "Ctrl Y", desc: "redo" },
+        { key: "Ctrl ↑", desc: "bring forward" },
+        { key: "Ctrl ↓", desc: "send backward" },
         { key: "F",      desc: "fit all in view" },
         { key: "H",      desc: "shortcuts" },
     ],

--- a/static/js/elements.js
+++ b/static/js/elements.js
@@ -12,6 +12,34 @@ export function reorderElements() {
     state.transformer.moveToTop();
 }
 
+export function bringForward(node) {
+    var children = state.layer.children;
+    var idx = children.indexOf(node);
+    if (idx < children.length - 1) {
+        var above = children[idx + 1];
+        if ((node instanceof Konva.Image && above instanceof Konva.Image) ||
+            (node instanceof Konva.Text  && above instanceof Konva.Text)) {
+            node.moveUp();
+            state.layer.batchDraw();
+            pushHistory();
+        }
+    }
+}
+
+export function sendBackward(node) {
+    var children = state.layer.children;
+    var idx = children.indexOf(node);
+    if (idx > 0) {
+        var below = children[idx - 1];
+        if ((node instanceof Konva.Image && below instanceof Konva.Image) ||
+            (node instanceof Konva.Text  && below instanceof Konva.Text)) {
+            node.moveDown();
+            state.layer.batchDraw();
+            pushHistory();
+        }
+    }
+}
+
 export function makeSelectable(node) {
     node.on("click tap", function (e) {
         e.cancelBubble = true;

--- a/static/js/elements.js
+++ b/static/js/elements.js
@@ -1,5 +1,5 @@
 import { state } from "./state.js";
-import { GRID_SIZE } from "./constants.js";
+import { GRID_SIZE, snapToGrid } from "./constants.js";
 import { generateId } from "./utils.js";
 // Note: history.js also imports from here — safe circular
 // because all cross-cycle calls happen inside function bodies, never at module eval time.
@@ -176,13 +176,13 @@ export function duplicateFrom(data, dx, dy) {
         var img = state.imageCache[data.src];
         if (!img) return;
         newNode = addImageNode({
-            id: generateId(), x: data.x + dx, y: data.y + dy,
+            id: generateId(), x: snapToGrid(data.x + dx), y: snapToGrid(data.y + dy),
             width: data.width, height: data.height,
             rotation: data.rotation, src: data.src,
         }, img);
         reorderElements();
     } else if (data.type === "text") {
-        newNode = createTextNode(data.x + dx, data.y + dy, data.content, data.fontSize, generateId(), data.width, data.rotation, data.fill, data.align);
+        newNode = createTextNode(snapToGrid(data.x + dx), snapToGrid(data.y + dy), data.content, data.fontSize, generateId(), data.width, data.rotation, data.fill, data.align);
     }
     if (newNode) { state.transformer.nodes([newNode]); state.layer.batchDraw(); pushHistory(); }
 }

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -3,6 +3,7 @@ import { generateId, toast } from "./utils.js";
 import { addImageNode, reorderElements } from "./elements.js";
 import { pushHistory } from "./history.js";
 import { updateBoardSize } from "./boardsize.js";
+import { snapToGrid } from "./constants.js";
 
 var MAX_DIMENSION = 2048;
 
@@ -74,8 +75,8 @@ export async function uploadAndAddImage(file) {
         var scale = Math.min(viewW * 0.8 / img.naturalWidth, viewH * 0.8 / img.naturalHeight);
         var w = img.naturalWidth  * scale;
         var h = img.naturalHeight * scale;
-        var x = -state.stage.x() / state.stage.scaleX() + viewW / 2 - w / 2;
-        var y = -state.stage.y() / state.stage.scaleY() + viewH / 2 - h / 2;
+        var x = snapToGrid(-state.stage.x() / state.stage.scaleX() + viewW / 2 - w / 2);
+        var y = snapToGrid(-state.stage.y() / state.stage.scaleY() + viewH / 2 - h / 2);
 
         state.imageCache[result.url] = img;
         var node = addImageNode({ id: generateId(), x, y, width: w, height: h, src: result.url }, img);

--- a/uv.lock
+++ b/uv.lock
@@ -131,7 +131,7 @@ wheels = [
 
 [[package]]
 name = "kemopin"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Closes #18

- Ctrl+Up to bring forward and Ctrl+Down to send backward, within type group (images stay below texts)
- Snap to grid on initial element placement (upload, duplicate, paste, double-click text), consistent with existing drag snap
- Performance audit: no code changes needed, image cache and batched draws already handle 50+ element boards well